### PR TITLE
Add simple Flask backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# PennyPilot Backend
+
+This simple Flask backend exposes REST API endpoints for managing
+transactions, categories, budgets and recurring items.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Run the application:
+
+```bash
+python app.py
+```
+
+The API uses an SQLite database `penny.db` in the repository directory.
+
+## Endpoints
+
+- `GET /categories`, `POST /categories`, `GET/PUT/DELETE /categories/<id>`
+- `GET /transactions`, `POST /transactions`, `GET/PUT/DELETE /transactions/<id>`
+- `GET /budgets`, `POST /budgets`, `GET/PUT/DELETE /budgets/<id>`
+- `GET /recurring_items`, `POST /recurring_items`, `GET/PUT/DELETE /recurring_items/<id>`
+
+All endpoints accept and return JSON.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,229 @@
+from datetime import date
+from flask import Flask, jsonify, request, abort
+
+from database import init_db, db
+from models import Category, Transaction, Budget, RecurringItem
+
+
+app = Flask(__name__)
+# Using SQLite database in the current directory
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///penny.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+init_db(app)
+
+
+# Helper for generic CRUD operations
+
+def get_model(model, model_id):
+    item = model.query.get(model_id)
+    if not item:
+        abort(404)
+    return item
+
+
+# Category endpoints
+@app.route("/categories", methods=["GET"])
+def list_categories():
+    return jsonify([c.to_dict() for c in Category.query.all()])
+
+
+@app.route("/categories", methods=["POST"])
+def create_category():
+    data = request.get_json() or {}
+    name = data.get("name")
+    if not name:
+        abort(400)
+    category = Category(name=name)
+    db.session.add(category)
+    db.session.commit()
+    return jsonify(category.to_dict()), 201
+
+
+@app.route("/categories/<int:category_id>", methods=["GET"])
+def get_category(category_id):
+    category = get_model(Category, category_id)
+    return jsonify(category.to_dict())
+
+
+@app.route("/categories/<int:category_id>", methods=["PUT"])
+def update_category(category_id):
+    category = get_model(Category, category_id)
+    data = request.get_json() or {}
+    if "name" in data:
+        category.name = data["name"]
+    db.session.commit()
+    return jsonify(category.to_dict())
+
+
+@app.route("/categories/<int:category_id>", methods=["DELETE"])
+def delete_category(category_id):
+    category = get_model(Category, category_id)
+    db.session.delete(category)
+    db.session.commit()
+    return "", 204
+
+
+# Transaction endpoints
+@app.route("/transactions", methods=["GET"])
+def list_transactions():
+    return jsonify([t.to_dict() for t in Transaction.query.all()])
+
+
+@app.route("/transactions", methods=["POST"])
+def create_transaction():
+    data = request.get_json() or {}
+    try:
+        t = Transaction(
+            description=data["description"],
+            amount=float(data["amount"]),
+            date=date.fromisoformat(data.get("date", date.today().isoformat())),
+            category_id=data.get("category_id", 1),
+        )
+    except (KeyError, ValueError):
+        abort(400)
+    db.session.add(t)
+    db.session.commit()
+    return jsonify(t.to_dict()), 201
+
+
+@app.route("/transactions/<int:transaction_id>", methods=["GET"])
+def get_transaction(transaction_id):
+    t = get_model(Transaction, transaction_id)
+    return jsonify(t.to_dict())
+
+
+@app.route("/transactions/<int:transaction_id>", methods=["PUT"])
+def update_transaction(transaction_id):
+    t = get_model(Transaction, transaction_id)
+    data = request.get_json() or {}
+    if "description" in data:
+        t.description = data["description"]
+    if "amount" in data:
+        t.amount = float(data["amount"])
+    if "date" in data:
+        t.date = date.fromisoformat(data["date"])
+    if "category_id" in data:
+        t.category_id = data["category_id"]
+    db.session.commit()
+    return jsonify(t.to_dict())
+
+
+@app.route("/transactions/<int:transaction_id>", methods=["DELETE"])
+def delete_transaction(transaction_id):
+    t = get_model(Transaction, transaction_id)
+    db.session.delete(t)
+    db.session.commit()
+    return "", 204
+
+
+# Budget endpoints
+@app.route("/budgets", methods=["GET"])
+def list_budgets():
+    return jsonify([b.to_dict() for b in Budget.query.all()])
+
+
+@app.route("/budgets", methods=["POST"])
+def create_budget():
+    data = request.get_json() or {}
+    try:
+        b = Budget(
+            name=data["name"],
+            amount=float(data["amount"]),
+            start_date=date.fromisoformat(data["start_date"]),
+            end_date=date.fromisoformat(data["end_date"]) if data.get("end_date") else None,
+        )
+    except (KeyError, ValueError):
+        abort(400)
+    db.session.add(b)
+    db.session.commit()
+    return jsonify(b.to_dict()), 201
+
+
+@app.route("/budgets/<int:budget_id>", methods=["GET"])
+def get_budget(budget_id):
+    b = get_model(Budget, budget_id)
+    return jsonify(b.to_dict())
+
+
+@app.route("/budgets/<int:budget_id>", methods=["PUT"])
+def update_budget(budget_id):
+    b = get_model(Budget, budget_id)
+    data = request.get_json() or {}
+    if "name" in data:
+        b.name = data["name"]
+    if "amount" in data:
+        b.amount = float(data["amount"])
+    if "start_date" in data:
+        b.start_date = date.fromisoformat(data["start_date"])
+    if "end_date" in data:
+        b.end_date = (
+            date.fromisoformat(data["end_date"]) if data["end_date"] else None
+        )
+    db.session.commit()
+    return jsonify(b.to_dict())
+
+
+@app.route("/budgets/<int:budget_id>", methods=["DELETE"])
+def delete_budget(budget_id):
+    b = get_model(Budget, budget_id)
+    db.session.delete(b)
+    db.session.commit()
+    return "", 204
+
+
+# RecurringItem endpoints
+@app.route("/recurring_items", methods=["GET"])
+def list_recurring_items():
+    return jsonify([r.to_dict() for r in RecurringItem.query.all()])
+
+
+@app.route("/recurring_items", methods=["POST"])
+def create_recurring_item():
+    data = request.get_json() or {}
+    try:
+        r = RecurringItem(
+            name=data["name"],
+            amount=float(data["amount"]),
+            frequency=data["frequency"],
+            next_due_date=date.fromisoformat(data["next_due_date"]),
+        )
+    except (KeyError, ValueError):
+        abort(400)
+    db.session.add(r)
+    db.session.commit()
+    return jsonify(r.to_dict()), 201
+
+
+@app.route("/recurring_items/<int:item_id>", methods=["GET"])
+def get_recurring_item(item_id):
+    r = get_model(RecurringItem, item_id)
+    return jsonify(r.to_dict())
+
+
+@app.route("/recurring_items/<int:item_id>", methods=["PUT"])
+def update_recurring_item(item_id):
+    r = get_model(RecurringItem, item_id)
+    data = request.get_json() or {}
+    if "name" in data:
+        r.name = data["name"]
+    if "amount" in data:
+        r.amount = float(data["amount"])
+    if "frequency" in data:
+        r.frequency = data["frequency"]
+    if "next_due_date" in data:
+        r.next_due_date = date.fromisoformat(data["next_due_date"])
+    db.session.commit()
+    return jsonify(r.to_dict())
+
+
+@app.route("/recurring_items/<int:item_id>", methods=["DELETE"])
+def delete_recurring_item(item_id):
+    r = get_model(RecurringItem, item_id)
+    db.session.delete(r)
+    db.session.commit()
+    return "", 204
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/database.py
+++ b/database.py
@@ -1,0 +1,12 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# SQLAlchemy instance used across the app
+
+db = SQLAlchemy()
+
+
+def init_db(app):
+    """Initialize the database with the Flask app."""
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,67 @@
+from datetime import date
+from database import db
+
+
+class Category(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+
+    def to_dict(self):
+        return {"id": self.id, "name": self.name}
+
+
+default_category_id = 1
+
+
+class Transaction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    description = db.Column(db.String(120), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    date = db.Column(db.Date, nullable=False, default=date.today)
+    category_id = db.Column(
+        db.Integer, db.ForeignKey("category.id"), nullable=False, default=default_category_id
+    )
+    category = db.relationship("Category")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "description": self.description,
+            "amount": self.amount,
+            "date": self.date.isoformat(),
+            "category_id": self.category_id,
+        }
+
+
+class Budget(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    start_date = db.Column(db.Date, nullable=False)
+    end_date = db.Column(db.Date, nullable=True)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "amount": self.amount,
+            "start_date": self.start_date.isoformat(),
+            "end_date": self.end_date.isoformat() if self.end_date else None,
+        }
+
+
+class RecurringItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    frequency = db.Column(db.String(20), nullable=False)  # e.g. weekly, monthly
+    next_due_date = db.Column(db.Date, nullable=False)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "amount": self.amount,
+            "frequency": self.frequency,
+            "next_due_date": self.next_due_date.isoformat(),
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.2
+Flask-SQLAlchemy==3.1.1


### PR DESCRIPTION
## Summary
- add Python/Flask backend with SQLite
- implement SQLAlchemy models for categories, transactions, budgets and recurring items
- expose REST endpoints for CRUD operations
- document setup steps and API usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417753ca48832fa075de6d1d8b16e7