### PR TITLE
Fix navigation and use modal forms

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -19,7 +19,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // Mobile navigation functionality
+    // navigation functionality
+    function showPage(name) {
+        document.querySelectorAll('.page').forEach(p => p.classList.add('hidden'));
+        const page = document.getElementById(`page-${name}`);
+        if (page) page.classList.remove('hidden');
+    }
+
     const mobileNavButtons = document.querySelectorAll('.lg\\:hidden button');
     mobileNavButtons.forEach(button => {
         button.addEventListener('click', () => {
@@ -29,10 +35,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             button.classList.remove('text-gray-400');
             button.classList.add('bg-accent-blue', 'text-white');
+            showPage(button.dataset.page);
         });
     });
 
-    // Desktop navigation functionality
     const desktopNavButtons = document.querySelectorAll('.hidden.lg\\:flex nav a');
     desktopNavButtons.forEach(button => {
         button.addEventListener('click', e => {
@@ -43,6 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             button.classList.remove('text-gray-400');
             button.classList.add('bg-accent-blue', 'text-white');
+            showPage(button.dataset.page);
         });
     });
 
@@ -69,6 +76,25 @@ document.addEventListener('DOMContentLoaded', () => {
     loadTransactions();
     loadBudgets();
     loadRecurringItems();
+
+    // modal helpers
+    const openModal = id => document.getElementById(id)?.classList.remove('hidden');
+    const closeModal = id => document.getElementById(id)?.classList.add('hidden');
+
+    document.getElementById('open-transaction-modal')?.addEventListener('click', () => openModal('transaction-modal'));
+    document.getElementById('open-transaction-modal-page')?.addEventListener('click', () => openModal('transaction-modal'));
+    document.getElementById('close-transaction-modal')?.addEventListener('click', () => closeModal('transaction-modal'));
+
+    document.getElementById('open-category-modal')?.addEventListener('click', () => openModal('category-modal'));
+    document.getElementById('open-category-modal-page')?.addEventListener('click', () => openModal('category-modal'));
+    document.getElementById('close-category-modal')?.addEventListener('click', () => closeModal('category-modal'));
+
+    document.getElementById('open-budget-modal')?.addEventListener('click', () => openModal('budget-modal'));
+    document.getElementById('close-budget-modal')?.addEventListener('click', () => closeModal('budget-modal'));
+
+    document.getElementById('open-recurring-modal')?.addEventListener('click', () => openModal('recurring-modal'));
+    document.getElementById('open-recurring-modal-page')?.addEventListener('click', () => openModal('recurring-modal'));
+    document.getElementById('close-recurring-modal')?.addEventListener('click', () => closeModal('recurring-modal'));
 
     // form handlers
     const categoryForm = document.getElementById('category-form');
@@ -114,13 +140,16 @@ async function api(url, options={}) {
 
 // Categories
 async function loadCategories() {
-    const list = document.getElementById('categories-list');
-    if (!list) return;
+    const lists = [
+        document.getElementById('categories-list'),
+        document.getElementById('categories-page-list')
+    ].filter(Boolean);
+    if (lists.length === 0) return;
     try {
         const data = await api('/categories');
-        list.innerHTML = '';
+        lists.forEach(l => l.innerHTML = '');
         if (data.length === 0) {
-            list.textContent = 'No categories';
+            lists.forEach(l => l.textContent = 'No categories');
             return;
         }
         data.forEach(c => {
@@ -131,7 +160,7 @@ async function loadCategories() {
                     <button class="text-xs text-blue-400 mr-2" onclick="editCategory(${c.id}, '${c.name}')">Edit</button>
                     <button class="text-xs text-red-400" onclick="deleteCategory(${c.id})">Delete</button>
                 </div>`;
-            list.appendChild(row);
+            lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
         list.textContent = 'Failed to load categories';
@@ -176,13 +205,16 @@ async function deleteCategory(id) {
 
 // Transactions
 async function loadTransactions() {
-    const list = document.getElementById('transactions-list');
-    if (!list) return;
+    const lists = [
+        document.getElementById('transactions-list'),
+        document.getElementById('transactions-page-list')
+    ].filter(Boolean);
+    if (lists.length === 0) return;
     try {
         const data = await api('/transactions');
-        list.innerHTML = '';
+        lists.forEach(l => l.innerHTML = '');
         if (data.length === 0) {
-            list.textContent = 'No transactions';
+            lists.forEach(l => l.textContent = 'No transactions');
             return;
         }
         data.forEach(t => {
@@ -193,7 +225,7 @@ async function loadTransactions() {
                     <button class="text-xs text-blue-400 mr-2" onclick="editTransaction(${t.id})">Edit</button>
                     <button class="text-xs text-red-400" onclick="deleteTransaction(${t.id})">Delete</button>
                 </div>`;
-            list.appendChild(row);
+            lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
         list.textContent = 'Failed to load transactions';
@@ -229,13 +261,15 @@ async function deleteTransaction(id) {
 
 // Budgets
 async function loadBudgets() {
-    const list = document.getElementById('budgets-list');
-    if (!list) return;
+    const lists = [
+        document.getElementById('budgets-list')
+    ].filter(Boolean);
+    if (lists.length === 0) return;
     try {
         const data = await api('/budgets');
-        list.innerHTML = '';
+        lists.forEach(l => l.innerHTML = '');
         if (data.length === 0) {
-            list.textContent = 'No budgets';
+            lists.forEach(l => l.textContent = 'No budgets');
             return;
         }
         data.forEach(b => {
@@ -246,7 +280,7 @@ async function loadBudgets() {
                     <button class="text-xs text-blue-400 mr-2" onclick="editBudget(${b.id})">Edit</button>
                     <button class="text-xs text-red-400" onclick="deleteBudget(${b.id})">Delete</button>
                 </div>`;
-            list.appendChild(row);
+            lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
         list.textContent = 'Failed to load budgets';
@@ -282,13 +316,16 @@ async function deleteBudget(id) {
 
 // Recurring items
 async function loadRecurringItems() {
-    const list = document.getElementById('recurring-list');
-    if (!list) return;
+    const lists = [
+        document.getElementById('recurring-list'),
+        document.getElementById('recurring-page-list')
+    ].filter(Boolean);
+    if (lists.length === 0) return;
     try {
         const data = await api('/recurring_items');
-        list.innerHTML = '';
+        lists.forEach(l => l.innerHTML = '');
         if (data.length === 0) {
-            list.textContent = 'No recurring items';
+            lists.forEach(l => l.textContent = 'No recurring items');
             return;
         }
         data.forEach(r => {
@@ -299,7 +336,7 @@ async function loadRecurringItems() {
                     <button class="text-xs text-blue-400 mr-2" onclick="editRecurring(${r.id})">Edit</button>
                     <button class="text-xs text-red-400" onclick="deleteRecurring(${r.id})">Delete</button>
                 </div>`;
-            list.appendChild(row);
+            lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
         list.textContent = 'Failed to load recurrings';

--- a/index.html
+++ b/index.html
@@ -52,27 +52,27 @@
             </div>
 
             <!-- Navigation -->
-            <nav class="space-y-2 mb-8">
-                <a href="#" class="flex items-center space-x-3 px-4 py-2 bg-accent-blue rounded-lg text-white">
+                        <nav class="space-y-2 mb-8">
+                <a href="#" data-page="dashboard" class="flex items-center space-x-3 px-4 py-2 bg-accent-blue rounded-lg text-white">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"></path>
                     </svg>
                     <span>Dashboard</span>
                 </a>
-                <a href="#" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
+                <a href="#" data-page="transactions" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H4a1 1 0 01-1-1v-6zM14 9a1 1 0 00-1 1v6a1 1 0 001 1h2a1 1 0 001-1v-6a1 1 0 00-1-1h-2z"></path>
                     </svg>
                     <span>Transactions</span>
                 </a>
-                <a href="#" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
+                <a href="#" data-page="categories" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
                         <path fill-rule="evenodd" d="M4 5a2 2 0 012-2v1a1 1 0 102 0V3a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 2a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"></path>
                     </svg>
                     <span>Categories</span>
                 </a>
-                <a href="#" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
+                <a href="#" data-page="recurrings" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"></path>
                     </svg>
@@ -99,6 +99,7 @@
 
         <!-- Main Content -->
         <div class="flex-1 p-8 overflow-y-auto">
+        <div id="page-dashboard" class="page">
             <h1 class="text-3xl font-bold mb-8">Dashboard</h1>
             
             <!-- Top Charts Row -->
@@ -155,16 +156,8 @@
                         <h2 class="text-xl font-semibold">Transactions To Review</h2>
                         <button class="text-accent-blue text-sm hover:underline">VIEW ALL →</button>
                     </div>
-                    
                     <div id="transactions-list" class="space-y-2 text-sm"></div>
-                    <form id="transaction-form" class="space-y-2 mt-4">
-                        <input id="transaction-desc" class="w-full p-1 text-black rounded" placeholder="Description">
-                        <input id="transaction-amount" type="number" step="0.01" class="w-full p-1 text-black rounded" placeholder="Amount">
-                        <input id="transaction-date" type="date" class="w-full p-1 text-black rounded">
-                        <select id="transaction-category" class="w-full p-1 text-black rounded"></select>
-                        <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Add Transaction</button>
-                    </form>
-
+                    <button id="open-transaction-modal" class="mt-2 bg-accent-blue text-white px-2 py-1 rounded">Add Transaction</button>
                     <button class="mt-6 w-full flex items-center justify-center space-x-2 py-2 text-accent-green text-sm hover:bg-dark-bg rounded-lg">
                         <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                             <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
@@ -176,12 +169,8 @@
                 <!-- Top Categories -->
                 <div class="bg-dark-card rounded-xl p-6">
                     <h2 class="text-xl font-semibold mb-6">Top Categories</h2>
-                    
                     <div id="categories-list" class="space-y-2 text-sm"></div>
-                    <form id="category-form" class="space-y-2 mt-4">
-                        <input id="category-name" class="w-full p-1 text-black rounded" placeholder="Category name">
-                        <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Add Category</button>
-                    </form>
+                    <button id="open-category-modal" class="mt-2 bg-accent-blue text-white px-2 py-1 rounded">Add Category</button>
                 </div>
             </div>
 
@@ -191,31 +180,34 @@
                     <h2 class="text-xl font-semibold">Monthly Income</h2>
                     <button class="text-accent-blue text-sm hover:underline">VIEW ALL →</button>
                 </div>
-                
                 <div id="budgets-list" class="space-y-2 text-sm mb-4"></div>
-                <form id="budget-form" class="space-y-2">
-                    <input id="budget-name" class="w-full p-1 text-black rounded" placeholder="Budget name">
-                    <input id="budget-amount" type="number" step="0.01" class="w-full p-1 text-black rounded" placeholder="Amount">
-                    <input id="budget-start" type="date" class="w-full p-1 text-black rounded">
-                    <input id="budget-end" type="date" class="w-full p-1 text-black rounded">
-                    <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Add Budget</button>
-                </form>
+                <button id="open-budget-modal" class="mt-2 bg-accent-blue text-white px-2 py-1 rounded">Add Budget</button>
             </div>
 
             <!-- Next Two Weeks Section -->
             <div class="bg-dark-card rounded-xl p-6 mt-8">
                 <h2 class="text-xl font-semibold mb-6">Next Two Weeks</h2>
                 <div id="recurring-list" class="space-y-2 text-sm"></div>
-                <form id="recurring-form" class="space-y-2 mt-4">
-                    <input id="recurring-name" class="w-full p-1 text-black rounded" placeholder="Name">
-                    <input id="recurring-amount" type="number" step="0.01" class="w-full p-1 text-black rounded" placeholder="Amount">
-                    <input id="recurring-frequency" class="w-full p-1 text-black rounded" placeholder="Frequency">
-                    <input id="recurring-next" type="date" class="w-full p-1 text-black rounded">
-                    <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Add Recurring</button>
-                </form>
+                <button id="open-recurring-modal" class="mt-2 bg-accent-blue text-white px-2 py-1 rounded">Add Recurring</button>
             </div>
         </div>
-    </div>
+        <div id="page-transactions" class="page hidden">
+            <h1 class="text-3xl font-bold mb-8">Transactions</h1>
+            <div id="transactions-page-list" class="space-y-2 text-sm mb-4"></div>
+            <button id="open-transaction-modal-page" class="bg-accent-blue text-white px-2 py-1 rounded">Add Transaction</button>
+        </div>
+
+        <div id="page-categories" class="page hidden">
+            <h1 class="text-3xl font-bold mb-8">Categories</h1>
+            <div id="categories-page-list" class="space-y-2 text-sm mb-4"></div>
+            <button id="open-category-modal-page" class="bg-accent-blue text-white px-2 py-1 rounded">Add Category</button>
+        </div>
+
+        <div id="page-recurrings" class="page hidden">
+            <h1 class="text-3xl font-bold mb-8">Recurring Items</h1>
+            <div id="recurring-page-list" class="space-y-2 text-sm mb-4"></div>
+            <button id="open-recurring-modal-page" class="bg-accent-blue text-white px-2 py-1 rounded">Add Recurring</button>
+        </div>
 
     <!-- Mobile Layout -->
     <div class="lg:hidden">
@@ -231,10 +223,10 @@
         <!-- Mobile Navigation -->
         <div class="bg-dark-sidebar border-t border-gray-700 px-4 py-2">
             <div class="flex space-x-6 overflow-x-auto">
-                <button class="px-4 py-2 bg-accent-blue text-white rounded-lg whitespace-nowrap">Dashboard</button>
-                <button class="px-4 py-2 text-gray-400 whitespace-nowrap">Transactions</button>
-                <button class="px-4 py-2 text-gray-400 whitespace-nowrap">Categories</button>
-                <button class="px-4 py-2 text-gray-400 whitespace-nowrap">Recurrings</button>
+                <button data-page="dashboard" class="px-4 py-2 bg-accent-blue text-white rounded-lg whitespace-nowrap">Dashboard</button>
+                <button data-page="transactions" class="px-4 py-2 text-gray-400 whitespace-nowrap">Transactions</button>
+                <button data-page="categories" class="px-4 py-2 text-gray-400 whitespace-nowrap">Categories</button>
+                <button data-page="recurrings" class="px-4 py-2 text-gray-400 whitespace-nowrap">Recurrings</button>
             </div>
         </div>
 
@@ -363,6 +355,60 @@
                 </button>
             </div>
         </div>
+    <!-- Modals -->
+    <div id="transaction-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div class="bg-dark-card p-4 rounded w-80">
+            <form id="transaction-form" class="space-y-2">
+                <input id="transaction-desc" class="w-full p-1 text-black rounded" placeholder="Description">
+                <input id="transaction-amount" type="number" step="0.01" class="w-full p-1 text-black rounded" placeholder="Amount">
+                <input id="transaction-date" type="date" class="w-full p-1 text-black rounded">
+                <select id="transaction-category" class="w-full p-1 text-black rounded"></select>
+                <div class="flex justify-end space-x-2">
+                    <button type="button" id="close-transaction-modal" class="px-2 py-1 bg-gray-700 text-white rounded">Cancel</button>
+                    <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="category-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div class="bg-dark-card p-4 rounded w-80">
+            <form id="category-form" class="space-y-2">
+                <input id="category-name" class="w-full p-1 text-black rounded" placeholder="Category name">
+                <div class="flex justify-end space-x-2">
+                    <button type="button" id="close-category-modal" class="px-2 py-1 bg-gray-700 text-white rounded">Cancel</button>
+                    <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="budget-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div class="bg-dark-card p-4 rounded w-80">
+            <form id="budget-form" class="space-y-2">
+                <input id="budget-name" class="w-full p-1 text-black rounded" placeholder="Budget name">
+                <input id="budget-amount" type="number" step="0.01" class="w-full p-1 text-black rounded" placeholder="Amount">
+                <input id="budget-start" type="date" class="w-full p-1 text-black rounded">
+                <input id="budget-end" type="date" class="w-full p-1 text-black rounded">
+                <div class="flex justify-end space-x-2">
+                    <button type="button" id="close-budget-modal" class="px-2 py-1 bg-gray-700 text-white rounded">Cancel</button>
+                    <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="recurring-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div class="bg-dark-card p-4 rounded w-80">
+            <form id="recurring-form" class="space-y-2">
+                <input id="recurring-name" class="w-full p-1 text-black rounded" placeholder="Name">
+                <input id="recurring-amount" type="number" step="0.01" class="w-full p-1 text-black rounded" placeholder="Amount">
+                <input id="recurring-frequency" class="w-full p-1 text-black rounded" placeholder="Frequency">
+                <input id="recurring-next" type="date" class="w-full p-1 text-black rounded">
+                <div class="flex justify-end space-x-2">
+                    <button type="button" id="close-recurring-modal" class="px-2 py-1 bg-gray-700 text-white rounded">Cancel</button>
+                    <button type="submit" class="bg-accent-blue text-white px-2 py-1 rounded">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
     </div>
 
     <script src="dashboard.js"></script>


### PR DESCRIPTION
## Summary
- implement page switching via data-page attribute navigation
- move inline forms into modal dialogs
- update API loaders to support new page lists

## Testing
- `python -m py_compile app.py database.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a22bac00832f87441d40a690b87d