### PR TITLE
Add budgets page and improve error handling

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -116,6 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('close-category-modal')?.addEventListener('click', () => closeModal('category-modal'));
 
     document.getElementById('open-budget-modal')?.addEventListener('click', openBudgetModal);
+    document.getElementById('open-budget-modal-page')?.addEventListener('click', openBudgetModal);
     document.getElementById('close-budget-modal')?.addEventListener('click', () => closeModal('budget-modal'));
 
     document.getElementById('open-recurring-modal')?.addEventListener('click', openRecurringModal);
@@ -189,7 +190,7 @@ async function loadCategories() {
             lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
-        list.textContent = 'Failed to load categories';
+        lists.forEach(l => l.textContent = 'Failed to load categories');
     }
 }
 
@@ -254,7 +255,7 @@ async function loadTransactions() {
             lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
-        list.textContent = 'Failed to load transactions';
+        lists.forEach(l => l.textContent = 'Failed to load transactions');
     }
 }
 
@@ -308,7 +309,8 @@ async function deleteTransaction(id) {
 // Budgets
 async function loadBudgets() {
     const lists = [
-        document.getElementById('budgets-list')
+        document.getElementById('budgets-list'),
+        document.getElementById('budgets-page-list')
     ].filter(Boolean);
     if (lists.length === 0) return;
     try {
@@ -329,7 +331,7 @@ async function loadBudgets() {
             lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
-        list.textContent = 'Failed to load budgets';
+        lists.forEach(l => l.textContent = 'Failed to load budgets');
     }
 }
 
@@ -406,7 +408,7 @@ async function loadRecurringItems() {
             lists.forEach(l => l.appendChild(row.cloneNode(true)));
         });
     } catch (err) {
-        list.textContent = 'Failed to load recurrings';
+        lists.forEach(l => l.textContent = 'Failed to load recurrings');
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -72,6 +72,12 @@
                     </svg>
                     <span>Categories</span>
                 </a>
+                <a href="#" data-page="budgets" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M3 3h14v2H3V3zm0 4h14v2H3V7zm0 4h14v2H3v-2zm0 4h14v2H3v-2z"></path>
+                    </svg>
+                    <span>Budgets</span>
+                </a>
                 <a href="#" data-page="recurrings" class="flex items-center space-x-3 px-4 py-2 text-gray-400 hover:text-white hover:bg-dark-card rounded-lg">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"></path>
@@ -197,6 +203,12 @@
             <div id="categories-page-list" class="space-y-2 text-sm mb-4"></div>
         </div>
 
+        <div id="page-budgets" class="page hidden">
+            <h1 class="text-3xl font-bold mb-8">Budgets</h1>
+            <button id="open-budget-modal-page" class="mb-4 bg-accent-blue text-white px-3 py-1 rounded">Add Budget</button>
+            <div id="budgets-page-list" class="space-y-2 text-sm mb-4"></div>
+        </div>
+
         <div id="page-recurrings" class="page hidden">
             <h1 class="text-3xl font-bold mb-8">Recurring Items</h1>
             <button id="open-recurring-modal-page" class="mb-4 bg-accent-blue text-white px-3 py-1 rounded">Add Recurring</button>
@@ -220,6 +232,7 @@
                 <button data-page="dashboard" class="px-4 py-2 bg-accent-blue text-white rounded-lg whitespace-nowrap">Dashboard</button>
                 <button data-page="transactions" class="px-4 py-2 text-gray-400 whitespace-nowrap">Transactions</button>
                 <button data-page="categories" class="px-4 py-2 text-gray-400 whitespace-nowrap">Categories</button>
+                <button data-page="budgets" class="px-4 py-2 text-gray-400 whitespace-nowrap">Budgets</button>
                 <button data-page="recurrings" class="px-4 py-2 text-gray-400 whitespace-nowrap">Recurrings</button>
             </div>
         </div>
@@ -340,6 +353,12 @@
                         <path fill-rule="evenodd" d="M4 5a2 2 0 012-2v1a1 1 0 102 0V3a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 2a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"></path>
                     </svg>
                     <span class="text-xs">Categories</span>
+                </button>
+                <button class="flex flex-col items-center space-y-1 text-gray-400">
+                    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M3 3h14v2H3V3zm0 4h14v2H3V7zm0 4h14v2H3v-2zm0 4h14v2H3v-2z"></path>
+                    </svg>
+                    <span class="text-xs">Budgets</span>
                 </button>
                 <button class="flex flex-col items-center space-y-1 text-gray-400">
                     <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">


### PR DESCRIPTION
## Summary
- add a dedicated Budgets page with Add button
- include Budgets in desktop and mobile navigation
- open budget modal from Budgets page
- show error messages correctly in load functions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c1a45a94832fb58f4b494138e8b5